### PR TITLE
German translation of "Complete campaign setup"

### DIFF
--- a/assets/i18n/de.po
+++ b/assets/i18n/de.po
@@ -4088,7 +4088,7 @@ msgid "Note campaign achievements"
 msgstr "Kampagnenerfolge notieren"
 
 msgid "Complete campaign setup"
-msgstr "Komplette Kampagnenvorbereitung"
+msgstr "Kampagnenvorbereitung abschließen"
 
 msgid "Review and draw tokens"
 msgstr "Marker prüfen und ziehen"


### PR DESCRIPTION
"Complete campaign setup" is translated to German incorrectly with "complete" as an adjective instead of a verb.